### PR TITLE
make parts of portkey http client configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,24 @@
-# Log level (debug, info, warn, error)
+# Log level (debug, info, warn, error) -- default: info
 LOG_LEVEL=debug
 
-# Transport type (stdio or sse)
+# Portkey settings (required)
+PORTKEY_API_KEY=super-secret-key
+
+# Portkey settings (optional)
+PORTKEY_BASE_URL=https://api.portkey.ai/v1
+PORTKEY_CLIENT_CUSTOM_CA_CERT_PATH=/path/to/custom/cert/file
+PORTKEY_CLIENT_INSECURE_SKIP_VERIFY=false
+PORTKEY_CLIENT_TIMEOUT=30s
+
+# Tool-specific settings (optional)
+TOOLS_PROMPT_RENDER_DESCRIPTION="A custom description for this tool, made available to agents"
+TOOLS_PROMPT_RENDER_ENABLED=true
+
+TOOLS_PROMPTS_LIST_DESCRIPTION="A custom description for this tool, made available to agents"
+TOOLS_PROMPTS_LIST_ENABLED=false
+
+# Transport type (stdio or sse) -- default: stdio
 TRANSPORT=sse
 
 # SSE transport settings (only needed if TRANSPORT=sse)
 TRANSPORT_SSE_ADDRESS=:8080
-
-# Portkey settings (required)
-PORTKEY_BASE_URL=https://api.portkey.ai/v1
-PORTKEY_API_KEY=super-secret-key
-
-# Optional tool-specific settings
-TOOLS_PROMPT_RENDER_ENABLED=true
-TOOLS_PROMPT_RENDER_DESCRIPTION="A custom description for this tool, made available to agents"
-
-TOOLS_PROMPTS_LIST_ENABLED=false
-TOOLS_PROMPTS_LIST_DESCRIPTION="A custom description for this tool, made available to agents"

--- a/internal/config/http_client.go
+++ b/internal/config/http_client.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+var (
+	ErrAppendCACert     = errors.New("failed to append custom CA cert")
+	ErrCACertNotExist   = errors.New("custom CA certificate path does not exist")
+	ErrInvalidTimeout   = errors.New("timeout must be greater than 0")
+	ErrReadCustomCACert = errors.New("failed to read custom CA cert")
+	ErrSystemCACertPool = errors.New("failed to get system CA cert pool")
+)
+
+type HTTPClient struct {
+	CustomCACertPath   string        `envconfig:"CUSTOM_CA_CERT_PATH" json:"custom_ca_cert_path"`
+	InsecureSkipVerify bool          `default:"false"                 envconfig:"INSECURE_SKIP_VERIFY" json:"insecure_skip_verify"` //nolint:lll
+	Timeout            time.Duration `default:"30s"                   envconfig:"TIMEOUT"              json:"timeout"`
+}
+
+func (cfg *HTTPClient) FromConfig() (*http.Client, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSystemCACertPool, err)
+	}
+
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	if cfg.CustomCACertPath != "" {
+		caCert, err := os.ReadFile(cfg.CustomCACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrReadCustomCACert, err)
+		}
+
+		if !rootCAs.AppendCertsFromPEM(caCert) {
+			return nil, ErrAppendCACert
+		}
+	}
+
+	return &http.Client{ //nolint:exhaustruct
+		Timeout: cfg.Timeout,
+		Transport: &http.Transport{ //nolint:exhaustruct
+			TLSClientConfig: &tls.Config{ //nolint:exhaustruct
+				InsecureSkipVerify: cfg.InsecureSkipVerify,
+				RootCAs:            rootCAs,
+			},
+		},
+	}, nil
+}
+
+func (cfg *HTTPClient) Validate() error {
+	if cfg.CustomCACertPath != "" {
+		if _, err := os.Stat(cfg.CustomCACertPath); os.IsNotExist(err) {
+			return fmt.Errorf("%w: %s", ErrCACertNotExist, cfg.CustomCACertPath)
+		}
+	}
+
+	if cfg.Timeout <= 0 {
+		return ErrInvalidTimeout
+	}
+
+	return nil
+}

--- a/internal/config/portkey.go
+++ b/internal/config/portkey.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/types"
 )
@@ -14,6 +15,7 @@ var (
 type Portkey struct {
 	APIKey  types.MaskedString `envconfig:"API_KEY"                 json:"api_key"       required:"true"`
 	BaseURL string             `default:"https://api.portkey.ai/v1" envconfig:"BASE_URL" json:"base_url" required:"true"` //nolint:lll
+	Client  HTTPClient         `envconfig:"CLIENT"                  json:"client"`
 }
 
 func (cfg *Portkey) Validate() error {
@@ -23,6 +25,10 @@ func (cfg *Portkey) Validate() error {
 
 	if cfg.APIKey == "" {
 		return ErrAPIKeyRequired
+	}
+
+	if err := cfg.Client.Validate(); err != nil {
+		return fmt.Errorf("invalid http client: %w", err)
 	}
 
 	return nil

--- a/internal/config/portkey_test.go
+++ b/internal/config/portkey_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/config"
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/types"
@@ -21,8 +22,13 @@ func TestPortkeyConfigMasking(t *testing.T) {
 	)
 
 	cfg := config.Portkey{
-		BaseURL: "https://api.portkey.example.com",
 		APIKey:  types.MaskedString(apiKey),
+		BaseURL: "https://api.portkey.example.com",
+		Client: config.HTTPClient{
+			CustomCACertPath:   "/foo/bar",
+			InsecureSkipVerify: false,
+			Timeout:            10 * time.Second,
+		},
 	}
 
 	// Test string representation via fmt - should be masked

--- a/internal/setup/mcp_tools.go
+++ b/internal/setup/mcp_tools.go
@@ -14,9 +14,14 @@ import (
 )
 
 func MCPTools(cfg config.App, mcpServer *server.MCPServer, downstreamTools ...tools.Tuple) error {
+	httpClient, err := cfg.Portkey.Client.FromConfig()
+	if err != nil {
+		return fmt.Errorf("failed to create http client from config: %w", err)
+	}
+
 	middlewares := []middleware.Middleware{
 		middleware.WithToolCallLogging,
-		middleware.WithHTTPClient(middleware.DefaultHTTPClient()),
+		middleware.WithHTTPClient(httpClient),
 	}
 
 	allTools := []tools.Tuple{


### PR DESCRIPTION
## Summary
Makes the Portkey HTTP client partially configurable

## Related Issues
N/A

## Specific Changes
- Timeout -- defaults `30s` 
- Custom CA Cert File to append -- defaults to "nothing to append"
- Insecure Skip Verify -- defaults `false`

## Testing
N/A

## Checklist
- [x] Documentation has been updated (if applicable)
