### PR TITLE
add prompt_create tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,11 +11,14 @@ PORTKEY_CLIENT_INSECURE_SKIP_VERIFY=false
 PORTKEY_CLIENT_TIMEOUT=30s
 
 # Tool-specific settings (optional)
+TOOLS_PROMPT_CREATE_DESCRIPTION="A custom description for this tool, made available to agents"
+TOOLS_PROMPT_CREATE_ENABLED=false
+
 TOOLS_PROMPT_RENDER_DESCRIPTION="A custom description for this tool, made available to agents"
 TOOLS_PROMPT_RENDER_ENABLED=true
 
 TOOLS_PROMPTS_LIST_DESCRIPTION="A custom description for this tool, made available to agents"
-TOOLS_PROMPTS_LIST_ENABLED=false
+TOOLS_PROMPTS_LIST_ENABLED=true
 
 # Transport type (stdio or sse) -- default: stdio
 TRANSPORT=sse

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ A Model Context Protocol (MCP) server implementation for Portkey. This applicati
 
 ## Supported MCP Features
 ### Tools
+- [`prompt_create`](https://portkey.ai/docs/api-reference/admin-api/control-plane/prompts/create-prompt)
 - [`prompt_render`](https://portkey.ai/docs/api-reference/inference-api/prompts/render)
-- [`prompts_list`](https://github.com/Portkey-AI/openapi/blob/master/openapi.yaml)
+- [`prompts_list`](https://portkey.ai/docs/api-reference/admin-api/control-plane/prompts/list-prompts)
 
 ## Installation
 

--- a/internal/config/tools.go
+++ b/internal/config/tools.go
@@ -4,19 +4,28 @@ import "fmt"
 
 const (
 	envPrefixTools        = "TOOLS"
+	envPrefixPromptCreate = "PROMPT_CREATE"
 	envPrefixPromptRender = "PROMPT_RENDER"
 	envPrefixPromptsList  = "PROMPTS_LIST"
 )
 
 type Tools struct {
+	PromptCreate BaseTool `envconfig:"PROMPT_CREATE"`
 	PromptRender BaseTool `envconfig:"PROMPT_RENDER"`
 	PromptsList  BaseTool `envconfig:"PROMPTS_LIST"`
 }
 
 func (t *Tools) Validate() error {
+	envPrefixPromptCreateTool := fmt.Sprintf("%s_%s", envPrefixTools, envPrefixPromptCreate)
+
+	err := t.PromptCreate.Validate(envPrefixPromptCreateTool)
+	if err != nil {
+		return fmt.Errorf("error validating prompt create tool: %w", err)
+	}
+
 	envPrefixPromptRenderTool := fmt.Sprintf("%s_%s", envPrefixTools, envPrefixPromptRender)
 
-	err := t.PromptRender.Validate(envPrefixPromptRenderTool)
+	err = t.PromptRender.Validate(envPrefixPromptRenderTool)
 	if err != nil {
 		return fmt.Errorf("error validating prompt render tool: %w", err)
 	}

--- a/internal/setup/mcp_tools.go
+++ b/internal/setup/mcp_tools.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/config"
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/tools"
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/tools/middleware"
+	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/tools/promptcreate"
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/tools/promptrender"
 	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/tools/promptslist"
 )
@@ -25,6 +26,7 @@ func MCPTools(cfg config.App, mcpServer *server.MCPServer, downstreamTools ...to
 	}
 
 	allTools := []tools.Tuple{
+		promptcreate.NewTool(cfg.Portkey, cfg.Tools.PromptCreate),
 		promptrender.NewTool(cfg.Portkey, cfg.Tools.PromptRender),
 		promptslist.NewTool(cfg.Portkey, cfg.Tools.PromptsList),
 	}

--- a/internal/tools/promptcreate/request.go
+++ b/internal/tools/promptcreate/request.go
@@ -1,0 +1,19 @@
+package promptcreate
+
+// Request represents the request body for the Portkey Prompt Create API.
+type Request struct {
+	// Required arguments
+	Name         string         `json:"name"`
+	CollectionID string         `json:"collection_id"`
+	String       string         `json:"string"`
+	Parameters   map[string]any `json:"parameters"`
+
+	// Optional arguments
+	Functions          []map[string]any `json:"functions,omitempty"`
+	Tools              []map[string]any `json:"tools,omitempty"`
+	ToolChoice         map[string]any   `json:"tool_choice,omitempty"`
+	Model              string           `json:"model,omitempty"`
+	VirtualKey         string           `json:"virtual_key,omitempty"`
+	VersionDescription string           `json:"version_description,omitempty"`
+	TemplateMetadata   map[string]any   `json:"template_metadata,omitempty"`
+}

--- a/internal/tools/promptcreate/response.go
+++ b/internal/tools/promptcreate/response.go
@@ -1,0 +1,9 @@
+package promptcreate
+
+// Response represents the full response structure from the Portkey Prompt Create API.
+type Response struct {
+	ID        string `json:"id"`
+	Slug      string `json:"slug"`
+	VersionID string `json:"version_id"`
+	Object    string `json:"object"`
+}

--- a/internal/tools/promptcreate/tool.go
+++ b/internal/tools/promptcreate/tool.go
@@ -1,0 +1,286 @@
+package promptcreate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/config"
+	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/tools"
+	"github.com/rvoh-emccaleb/portkey-mcp-server/internal/tools/middleware"
+)
+
+const (
+	toolName = "prompt_create"
+
+	// Tool arguments.
+	toolArgName               = "name"
+	toolArgCollectionID       = "collection_id"
+	toolArgString             = "string"
+	toolArgParameters         = "parameters"
+	toolArgFunctions          = "functions"
+	toolArgTools              = "tools"
+	toolArgToolChoice         = "tool_choice"
+	toolArgModel              = "model"
+	toolArgVirtualKey         = "virtual_key"
+	toolArgVersionDescription = "version_description"
+	toolArgTemplateMetadata   = "template_metadata"
+
+	errTextInternalError = "internal error while processing request"
+)
+
+var (
+	ErrNameRequired         = errors.New("name is required")
+	ErrCollectionIDRequired = errors.New("collection_id is required")
+	ErrStringRequired       = errors.New("string is required")
+	ErrParametersRequired   = errors.New("parameters is required")
+	ErrInvalidArrayFormat   = errors.New("invalid array format: expected array of objects")
+)
+
+type toolArgs struct {
+	name               string
+	collectionID       string
+	promptString       string
+	parameters         map[string]any
+	functions          []map[string]any
+	tools              []map[string]any
+	toolChoice         map[string]any
+	model              string
+	virtualKey         string
+	versionDescription string
+	templateMetadata   map[string]any
+}
+
+func NewTool(portkeyCfg config.Portkey, toolCfg config.BaseTool) tools.Tuple {
+	description := "Create a new prompt in your Portkey account with the provided arguments. " +
+		"This tool allows you to create a prompt with a name, template string, parameters, " +
+		"and other optional settings."
+
+	if toolCfg.Description != "" {
+		description = toolCfg.Description
+	}
+
+	promptCreateTool := mcp.NewTool(
+		toolName,
+		mcp.WithDescription(description),
+		mcp.WithString(toolArgName,
+			mcp.Required(),
+			mcp.Description("Name of the prompt to create."),
+		),
+		mcp.WithString(toolArgCollectionID,
+			mcp.Required(),
+			mcp.Description("UUID or slug of the collection to add the prompt to."),
+		),
+		mcp.WithString(toolArgString,
+			mcp.Required(),
+			mcp.Description("Prompt template in string format. Use {{variable_name}} syntax "+
+				"to define variables that can be substituted at runtime (e.g., 'Hello {{name}}, how are you?')."),
+		),
+		mcp.WithObject(toolArgParameters,
+			mcp.Required(),
+			mcp.Description("Parameters for the prompt. This defines the variable schema for the template. "+
+				"Each key in this object will be available as {{key}} in the prompt template. Uses Mustache templating - "+
+				"keys should be the variable names with values as expected data types "+
+				"(e.g., {\"name\": \"string\", \"age\": \"number\"}). "+
+				"At runtime, users will provide actual values for these variables."),
+		),
+		mcp.WithArray(toolArgFunctions,
+			mcp.Description("Functions for the prompt."),
+		),
+		mcp.WithArray(toolArgTools,
+			mcp.Description("Tools for the prompt."),
+		),
+		mcp.WithObject(toolArgToolChoice,
+			mcp.Description("Tool Choice for the prompt."),
+		),
+		mcp.WithString(toolArgModel,
+			mcp.Description("The model to use for the prompt."),
+		),
+		mcp.WithString(toolArgVirtualKey,
+			mcp.Description("The virtual key to use for the prompt."),
+		),
+		mcp.WithString(toolArgVersionDescription,
+			mcp.Description("The description of the prompt version."),
+		),
+		mcp.WithObject(toolArgTemplateMetadata,
+			mcp.Description("Metadata for the prompt."),
+		),
+	)
+
+	return tools.Tuple{
+		Tool:    &promptCreateTool,
+		Handler: promptCreateHandler(portkeyCfg),
+		Enabled: toolCfg.Enabled,
+	}
+}
+
+// promptCreateHandler calls the Portkey Prompt Create API and returns the result.
+// Note: For validation errors (e.g. missing required fields), specific error messages are returned.
+// For internal/system errors, generic error messages are returned while details are logged.
+func promptCreateHandler(portkey config.Portkey) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		lgr := middleware.GetLogger(ctx)
+
+		args, err := getToolArguments(request)
+		if err != nil {
+			lgr.Info("failed to get user-provided tool arguments from mcp request", "error", err)
+
+			return mcp.NewToolResultErrorFromErr("invalid input", err), nil
+		}
+
+		url := portkey.BaseURL + "/prompts"
+
+		body, err := createReqBody(args)
+		if err != nil {
+			lgr.Error("failed to create request body", "error", err)
+
+			return mcp.NewToolResultError(errTextInternalError), nil
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			lgr.Error("failed to create http request", "error", err)
+
+			return mcp.NewToolResultError(errTextInternalError), nil
+		}
+
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("X-Portkey-Api-Key", string(portkey.APIKey))
+
+		resp, err := tools.MakePortkeyAPIRequest(ctx, httpReq)
+		if err != nil {
+			lgr.Error("failed to call portkey api", "error", err)
+
+			return mcp.NewToolResultError("failed to communicate with portkey service"), nil
+		}
+		defer resp.Body.Close()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			lgr.Error("failed to read response body", "error", err)
+
+			return mcp.NewToolResultError("failed to process portkey response"), nil
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return tools.HandleHTTPError(resp, respBody, lgr), nil
+		}
+
+		var portkeyResp Response
+		if err := json.Unmarshal(respBody, &portkeyResp); err != nil {
+			lgr.Error("invalid response format received from portkey service", "error", err)
+
+			return mcp.NewToolResultError("received invalid response from portkey service"), nil
+		}
+
+		return mcp.NewToolResultText(string(respBody)), nil
+	}
+}
+
+func getToolArguments(request mcp.CallToolRequest) (toolArgs, error) {
+	name := mcp.ParseString(request, toolArgName, "")
+	if name == "" {
+		return toolArgs{}, ErrNameRequired
+	}
+
+	collectionID := mcp.ParseString(request, toolArgCollectionID, "")
+	if collectionID == "" {
+		return toolArgs{}, ErrCollectionIDRequired
+	}
+
+	promptString := mcp.ParseString(request, toolArgString, "")
+	if promptString == "" {
+		return toolArgs{}, ErrStringRequired
+	}
+
+	parameters := mcp.ParseStringMap(request, toolArgParameters, nil)
+	if parameters == nil {
+		return toolArgs{}, ErrParametersRequired
+	}
+
+	// Optional arguments
+	functions, err := extractArrayOfObjects(request, toolArgFunctions)
+	if err != nil {
+		return toolArgs{}, err
+	}
+
+	tools, err := extractArrayOfObjects(request, toolArgTools)
+	if err != nil {
+		return toolArgs{}, err
+	}
+
+	toolChoice := mcp.ParseStringMap(request, toolArgToolChoice, nil)
+	model := mcp.ParseString(request, toolArgModel, "")
+	virtualKey := mcp.ParseString(request, toolArgVirtualKey, "")
+	versionDescription := mcp.ParseString(request, toolArgVersionDescription, "")
+	templateMetadata := mcp.ParseStringMap(request, toolArgTemplateMetadata, nil)
+
+	return toolArgs{
+		name:               name,
+		collectionID:       collectionID,
+		promptString:       promptString,
+		parameters:         parameters,
+		functions:          functions,
+		tools:              tools,
+		toolChoice:         toolChoice,
+		model:              model,
+		virtualKey:         virtualKey,
+		versionDescription: versionDescription,
+		templateMetadata:   templateMetadata,
+	}, nil
+}
+
+func extractArrayOfObjects(request mcp.CallToolRequest, argName string) ([]map[string]any, error) {
+	rawValue, exists := request.Params.Arguments[argName]
+	if !exists || rawValue == nil {
+		return nil, nil
+	}
+
+	rawArray, ok := rawValue.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%w for argument %q", ErrInvalidArrayFormat, argName)
+	}
+
+	result := make([]map[string]any, 0, len(rawArray))
+
+	for i, item := range rawArray {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%w for argument %q at index %d", ErrInvalidArrayFormat, argName, i)
+		}
+
+		result = append(result, obj)
+	}
+
+	return result, nil
+}
+
+func createReqBody(args toolArgs) ([]byte, error) {
+	req := Request{
+		Name:               args.name,
+		CollectionID:       args.collectionID,
+		String:             args.promptString,
+		Parameters:         args.parameters,
+		Functions:          args.functions,
+		Tools:              args.tools,
+		ToolChoice:         args.toolChoice,
+		Model:              args.model,
+		VirtualKey:         args.virtualKey,
+		VersionDescription: args.versionDescription,
+		TemplateMetadata:   args.templateMetadata,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	return data, nil
+}

--- a/internal/tools/promptrender/request.go
+++ b/internal/tools/promptrender/request.go
@@ -2,10 +2,10 @@ package promptrender
 
 // Request represents the request body for the Portkey Prompt Render API.
 type Request struct {
-	// Required parameters
+	// Required arguments
 	Variables map[string]string `json:"variables"`
 
-	// Optional parameters - all at root level as per API spec
+	// Optional arguments - all at root level as per API spec
 	Messages          []Message       `json:"messages,omitempty"`
 	Model             string          `json:"model,omitempty"`
 	FrequencyPenalty  *float64        `json:"frequency_penalty,omitempty"`
@@ -17,16 +17,16 @@ type Request struct {
 	PresencePenalty   *float64        `json:"presence_penalty,omitempty"`
 	ResponseFormat    *ResponseFormat `json:"response_format,omitempty"`
 	Seed              *int64          `json:"seed,omitempty"`
-	Stop              interface{}     `json:"stop,omitempty"` // Can be string or []string
+	Stop              any             `json:"stop,omitempty"` // Can be string or []string
 	Stream            bool            `json:"stream,omitempty"`
 	StreamOptions     *StreamOptions  `json:"stream_options,omitempty"`
 	Thinking          *ThinkingConfig `json:"thinking,omitempty"`
 	Temperature       *float64        `json:"temperature,omitempty"`
 	TopP              *float64        `json:"top_p,omitempty"`
 	Tools             []Tool          `json:"tools,omitempty"`
-	ToolChoice        interface{}     `json:"tool_choice,omitempty"` // Can be string or object
+	ToolChoice        any             `json:"tool_choice,omitempty"` // Can be string or object
 	ParallelToolCalls bool            `json:"parallel_tool_calls,omitempty"`
 	User              string          `json:"user,omitempty"`
-	FunctionCall      interface{}     `json:"function_call,omitempty"` // Deprecated
+	FunctionCall      any             `json:"function_call,omitempty"` // Deprecated
 	Functions         []Function      `json:"functions,omitempty"`     // Deprecated
 }

--- a/internal/tools/promptrender/response.go
+++ b/internal/tools/promptrender/response.go
@@ -10,7 +10,8 @@ type Response struct {
 type RenderData struct {
 	Messages []Message `json:"messages"`
 	Model    string    `json:"model"`
-	// Optional parameters
+
+	// Optional fields
 	FrequencyPenalty  *float64        `json:"frequency_penalty,omitempty"`
 	LogitBias         map[string]int  `json:"logit_bias,omitempty"`
 	LogProbs          bool            `json:"logprobs,omitempty"`
@@ -20,17 +21,17 @@ type RenderData struct {
 	PresencePenalty   *float64        `json:"presence_penalty,omitempty"`
 	ResponseFormat    *ResponseFormat `json:"response_format,omitempty"`
 	Seed              *int64          `json:"seed,omitempty"`
-	Stop              interface{}     `json:"stop,omitempty"` // Can be string or []string
+	Stop              any             `json:"stop,omitempty"` // Can be string or []string
 	Stream            bool            `json:"stream,omitempty"`
 	StreamOptions     *StreamOptions  `json:"stream_options,omitempty"`
 	Thinking          *ThinkingConfig `json:"thinking,omitempty"`
 	Temperature       *float64        `json:"temperature,omitempty"`
 	TopP              *float64        `json:"top_p,omitempty"`
 	Tools             []Tool          `json:"tools,omitempty"`
-	ToolChoice        interface{}     `json:"tool_choice,omitempty"` // Can be string or object
+	ToolChoice        any             `json:"tool_choice,omitempty"` // Can be string or object
 	ParallelToolCalls bool            `json:"parallel_tool_calls,omitempty"`
 	User              string          `json:"user,omitempty"`
-	FunctionCall      interface{}     `json:"function_call,omitempty"` // Deprecated
+	FunctionCall      any             `json:"function_call,omitempty"` // Deprecated
 	Functions         []Function      `json:"functions,omitempty"`     // Deprecated
 }
 
@@ -59,7 +60,7 @@ type Tool struct {
 }
 
 type Function struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description,omitempty"`
-	Parameters  map[string]interface{} `json:"parameters,omitempty"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
 }

--- a/internal/tools/promptslist/request.go
+++ b/internal/tools/promptslist/request.go
@@ -2,7 +2,7 @@ package promptslist
 
 // Request represents the request body for the Portkey Prompts List API.
 type Request struct {
-	// Optional parameters
+	// Optional arguments
 	CollectionID string `json:"collection_id,omitempty"`
 	WorkspaceID  string `json:"workspace_id,omitempty"`
 	CurrentPage  *int   `json:"current_page,omitempty"`


### PR DESCRIPTION
## Summary
Adds `prompt_create` tool.

## Related Issues
N/A

## Specific updates
- Adds `prompt_create` tool
- Replaces `interface{}` with `any`
- Uses proper names when referring to MCP tool parameters and arguments -- not mixing the two, improperly

## Testing
N/A

## Checklist
- [x] Documentation has been updated (if applicable)
